### PR TITLE
Feat/noninteractive mode

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -42,6 +42,9 @@ $FontAwesomeUpgrade = Get-FontAwesomeMap
 # Add Hudu Relations Function
 . $PSScriptRoot\Public\Add-HuduRelation.ps1
 
+# Add Timed (Noninteractive) Messages Helper
+. $PSScriptRoot\Public\Write-TimedMessage.ps1
+
 ############################### End of Functions ###############################
 
 
@@ -90,7 +93,7 @@ Write-Host "It is unofficial and you run it entirely at your own risk" -Foregrou
 Write-Host "You accept full responsibility for any problems caused by running it" -ForegroundColor Red
 Write-Host "######################################################" -ForegroundColor Red
 
-$backups = Read-Host "Y/n"
+$backups=$(if ($true -eq $NonInteractive) {"Y"} else {Read-Host "Y/n"})
 
 $ScriptStartTime = $(Get-Date -Format "o")
 
@@ -147,7 +150,7 @@ if (Test-Path -Path "$MigrationLogs") {
         $ResumeFound = $true
     } else {
         Write-Host "A previous attempt has been found, resume is disabled so this will be lost, if you haven't reverted to a snapshot, a resume is recommended" -ForegroundColor Red
-        Read-Host "Press any key to continue or ctrl + c to quit and edit the ResumePrevious setting"
+        Write-TimedMessage -Timeout 3 -Message "Press any key to continue or ctrl + c to quit and edit the ResumePrevious setting"
         $ResumeFound = $false
     }
 } else {
@@ -231,7 +234,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
     Write-Host "Your Internal Company has been matched to: $(($MatchedCompanies | Sort-Object CompanyName | Where-Object {$_.InternalCompany -eq $true} | Select-Object CompanyName).companyname) in IT Glue"
     Write-Host "The documents under this customer will be migrated to the Global KB in Hudu"
     Write-Host ""
-    Read-Host -Prompt "Press Return to continue or CTRL+C to quit if this is not correct" 
+    Write-TimedMessage -Message "Internal Company Correct? Press Return to continue or CTRL+C to quit if this is not correct" -Timeout 5
 
     Write-Host "Matched Companies (Already exist so will not be migrated)"
     $MatchedCompanies | Sort-Object CompanyName | Where-Object { $_.Matched -eq $true } | Select-Object CompanyName | Format-Table
@@ -307,13 +310,13 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
             Write-Host "All Companies matched, no migration required" -foregroundcolor green
         } else {
             Write-Host "Warning Import Companies is set to disabled so the above unmatched companies will not have data migrated" -foregroundcolor red
-            Read-Host -Prompt "Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Message "Press any key to continue or CTRL+C to quit" 
         }
     }
 
     # Save the results to resume from if needed
     $MatchedCompanies | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Companies.json"
-    Read-Host "Snapshot Point: Companies Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Companies Migrated Continue?"
 
 }
 
@@ -428,7 +431,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Locations.json")) {
 
     # Save the results to resume from if needed
     $MatchedLocations | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Locations.json"
-    Read-Host "Snapshot Point: Locations Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Locations Migrated Continue?"
 
 }
 
@@ -523,14 +526,13 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Websites.json")) {
         if ($UnmappedWebsiteCount -eq 0) {
             Write-Host "All $MigrationName matched, no migration required" -foregroundcolor green
         } else {
-            Write-Host "Warning Import Websites is set to disabled so the above unmatched Websites will not have data migrated" -foregroundcolor red
-            Read-Host -Prompt "Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Timeout 9 -Message "Warning Import Websites is set to disabled so the above unmatched Websites will not have data migrated... Press any key to continue or CTRL+C to quit" 
         }
     }
 
     # Save the results to resume from if needed
     $MatchedWebsites | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Websites.json"
-    Read-Host "Snapshot Point: Websites Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Websites Migrated Continue?"
 
 }
 
@@ -804,7 +806,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
             Write-Host ""
             Write-Host "Processing $ConfigType"
             Write-Host "Please provide the Asset Layout name for $ConfigType in Hudu." -foregroundcolor green
-            $ConfigImportAssetLayoutName = Read-Host "Please enter layout name"
+            $ConfigImportAssetLayoutName = $(Write-TimedMessage -Timeout 24 -Message "Please enter layout name" -DefaultResponse $ConfigType)
 		
 
             $ParsedITGConfigs = $ITGConfigurations | Where-Object -filter { $_.attributes."configuration-type-name" -eq $ConfigType }
@@ -840,7 +842,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
 
     # Save the results to resume from if needed
     $MatchedConfigurations | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Configurations.json"
-    Read-Host "Snapshot Point: Configurations Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Configurations Migrated Continue?"
 
 }
 
@@ -960,7 +962,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Contacts.json")) {
 
     # Save the results to resume from if needed
     $MatchedContacts | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Contacts.json"
-    Read-Host "Snapshot Point: Contacts Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Contacts Migrated Continue?"
 
 }
 
@@ -1228,7 +1230,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\AssetLayouts.json")) 
 
     $AllFields | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetLayoutsFields.json"
     $MatchedLayouts | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetLayouts.json"
-    Read-Host "Snapshot Point: Layouts Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Layouts Migrated Continue?"
 
 }
 
@@ -1454,7 +1456,7 @@ $ITGPasswordsRaw = Import-CSV -Path "$ITGLueExportPath\passwords.csv"
         $MatchedAssetPasswords | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetPasswords.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
         $RelationsToCreate | ConvertTo-Json -Depth 20 | Out-File "$MigrationLogs\RelationsToCreate.json"
-        Read-Host "Snapshot Point: Assets Migrated Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Assets Migrated Continue?"
     }
 }
 
@@ -1584,7 +1586,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\ArticleBase.json")) {
         }
         $MatchedArticles | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ArticleBase.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-        Read-Host "Snapshot Point: Stub Articles Created Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Stub Articles Created Continue?"
     }
 
 }
@@ -1826,7 +1828,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
         $MatchedArticles | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Articles.json"
         $ArticleErrors | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ArticleErrors.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-        Read-Host "Snapshot Point: Articles Created Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Articles Created Continue?"
 
     }
 
@@ -2021,14 +2023,14 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
             Write-Host "All Passwords matched, no migration required" -foregroundcolor green
         } else {
             Write-Host "Warning Import passwords is set to disabled so the above unmatched passwords will not have data migrated" -foregroundcolor red
-            Read-Host -Prompt "Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Timeout 3 -Message "Press any key to continue or CTRL+C to quit" 
         }
     }
 
     # Save the results to resume from if needed
     $MatchedPasswords | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Passwords.json"
     $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-    Read-Host "Snapshot Point: Passwords Finished. Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Passwords Finished. Continue?"
 }
 
 ############################## Update ITGlue URLs on All Areas to Hudu #######################
@@ -2059,7 +2061,7 @@ foreach ($articleFound in $UpdateArticles) {
 }
 
 $articlesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedArticlesURL.json"
-Read-Host "Snapshot Point: Article URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. Continue?"
 
 # Assets
 $assetsUpdated = @()
@@ -2085,7 +2087,7 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
 }
 
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
-Read-Host "Snapshot Point: Assets URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?"
 
 # Passwords
 $passwordsUpdated = @()
@@ -2098,7 +2100,7 @@ foreach ($passwordFound in $UpdatePasswords.HuduObject) {
     }
 }
 $passwordsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedPasswordsURL.json"
-Read-Host "Snapshot Point: Password URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Password URLs Replaced. Continue?"
 
 # Asset Passwords
 $assetPasswordsUpdated = @()
@@ -2113,7 +2115,7 @@ foreach ($passwordFound in $UpdateAssetPasswords) {
     
 }
 $assetPasswordsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetPasswordsURL.json"
-Read-Host "Snapshot Point: Asset Passwords URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Asset Passwords URLs Replaced. Continue?"
 
 # Company Notes
 $companyNotesUpdated = @()
@@ -2127,7 +2129,7 @@ foreach ($companyFound in $UpdateCompanyNotes.HuduCompanyObject) {
 
 }
 $companyNotesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedCompaniesURL.json"
-Read-Host "Snapshot Point: Company Notes URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Company Notes URLs Replaced. Continue?"
 
 ############################### Generate Manual Actions Report ###############################
 
@@ -2257,6 +2259,6 @@ Write-Host "$(($MatchedPasswords | Measure-Object).count) : Passwords Migrated" 
 Write-Host "#######################################################" -ForegroundColor Green
 Write-Host "Manual Actions report can be found in ManualActions.html in the folder the script was run from"
 Write-Host "Logs of what was migrated can be found in the MigrationLogs folder"
-Read-Host "Press any key to view the manual actions report or Ctrl+C to end"
+Write-TimedMessage -Message "Press any key to view the manual actions report or Ctrl+C to end" -Timeout 3600
 
 Start-Process ManualActions.html

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -150,7 +150,7 @@ if (Test-Path -Path "$MigrationLogs") {
         $ResumeFound = $true
     } else {
         Write-Host "A previous attempt has been found, resume is disabled so this will be lost, if you haven't reverted to a snapshot, a resume is recommended" -ForegroundColor Red
-        Write-TimedMessage -Timeout 3 -Message "Press any key to continue or ctrl + c to quit and edit the ResumePrevious setting"
+        Write-TimedMessage -Timeout 12 -Message "Press any key to continue or ctrl + c to quit and edit the ResumePrevious setting" -DefaultResponse "proceed with new migration, do not resume"
         $ResumeFound = $false
     }
 } else {
@@ -234,7 +234,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
     Write-Host "Your Internal Company has been matched to: $(($MatchedCompanies | Sort-Object CompanyName | Where-Object {$_.InternalCompany -eq $true} | Select-Object CompanyName).companyname) in IT Glue"
     Write-Host "The documents under this customer will be migrated to the Global KB in Hudu"
     Write-Host ""
-    Write-TimedMessage -Message "Internal Company Correct? Press Return to continue or CTRL+C to quit if this is not correct" -Timeout 5
+    Write-TimedMessage -Message "Internal Company Correct? Press Return to continue or CTRL+C to quit if this is not correct" -Timeout 12 -DefaultResponse "Assuming found match on '$(($MatchedCompanies | Sort-Object CompanyName | Where-Object {$_.InternalCompany -eq $true} | Select-Object CompanyName).companyname)' is correct."
 
     Write-Host "Matched Companies (Already exist so will not be migrated)"
     $MatchedCompanies | Sort-Object CompanyName | Where-Object { $_.Matched -eq $true } | Select-Object CompanyName | Format-Table
@@ -310,13 +310,13 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
             Write-Host "All Companies matched, no migration required" -foregroundcolor green
         } else {
             Write-Host "Warning Import Companies is set to disabled so the above unmatched companies will not have data migrated" -foregroundcolor red
-            Write-TimedMessage -Message "Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Message "Press any key to continue or CTRL+C to quit" -DefaultResponse "continue and wrap-up companies, please." -Timeout 6
         }
     }
 
     # Save the results to resume from if needed
     $MatchedCompanies | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Companies.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Companies Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Companies Migrated Continue?"  -DefaultResponse "continue to Locations, please."
 
 }
 
@@ -431,7 +431,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Locations.json")) {
 
     # Save the results to resume from if needed
     $MatchedLocations | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Locations.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Locations Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Locations Migrated Continue?"  -DefaultResponse "continue to Websites, please."
 
 }
 
@@ -526,13 +526,13 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Websites.json")) {
         if ($UnmappedWebsiteCount -eq 0) {
             Write-Host "All $MigrationName matched, no migration required" -foregroundcolor green
         } else {
-            Write-TimedMessage -Timeout 9 -Message "Warning Import Websites is set to disabled so the above unmatched Websites will not have data migrated... Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Timeout 12 -Message "Warning Import Websites is set to disabled so the above unmatched Websites will not have data migrated... Press any key to continue or CTRL+C to quit"  -DefaultResponse "continue and wrap-up Websites, please."
         }
     }
 
     # Save the results to resume from if needed
     $MatchedWebsites | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Websites.json"
-    Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Websites Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Websites Migrated Continue?"  -DefaultResponse "continue to Configurations, please."
 
 }
 
@@ -806,7 +806,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
             Write-Host ""
             Write-Host "Processing $ConfigType"
             Write-Host "Please provide the Asset Layout name for $ConfigType in Hudu." -foregroundcolor green
-            $ConfigImportAssetLayoutName = $(Write-TimedMessage -Timeout 24 -Message "Please enter layout name" -DefaultResponse $ConfigType)
+            $ConfigImportAssetLayoutName = $(Write-TimedMessage -Timeout 12 -Message "Please enter layout name" -DefaultResponse $ConfigType)
 		
 
             $ParsedITGConfigs = $ITGConfigurations | Where-Object -filter { $_.attributes."configuration-type-name" -eq $ConfigType }
@@ -842,7 +842,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
 
     # Save the results to resume from if needed
     $MatchedConfigurations | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Configurations.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Configurations Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Configurations Migrated Continue?"  -DefaultResponse "continue to Contacts, please."
 
 }
 
@@ -962,7 +962,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Contacts.json")) {
 
     # Save the results to resume from if needed
     $MatchedContacts | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Contacts.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Contacts Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Contacts Migrated Continue?"  -DefaultResponse "continue to Flexible Asset Layouts, please."
 
 }
 
@@ -1230,7 +1230,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\AssetLayouts.json")) 
 
     $AllFields | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetLayoutsFields.json"
     $MatchedLayouts | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetLayouts.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Layouts Migrated Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Layouts Migrated Continue?"  -DefaultResponse "continue to Flexible Assets, please."
 
 }
 
@@ -1456,7 +1456,7 @@ $ITGPasswordsRaw = Import-CSV -Path "$ITGLueExportPath\passwords.csv"
         $MatchedAssetPasswords | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\AssetPasswords.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
         $RelationsToCreate | ConvertTo-Json -Depth 20 | Out-File "$MigrationLogs\RelationsToCreate.json"
-        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Assets Migrated Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Assets Migrated Continue?" -DefaultResponse "continue to Documents/Articles, please."
     }
 }
 
@@ -1586,7 +1586,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\ArticleBase.json")) {
         }
         $MatchedArticles | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ArticleBase.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Stub Articles Created Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Stub Articles Created Continue?"  -DefaultResponse "continue to Document/Article Bodies, please."
     }
 
 }
@@ -1828,7 +1828,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
         $MatchedArticles | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Articles.json"
         $ArticleErrors | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ArticleErrors.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Articles Created Continue?"
+        Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Articles Created Continue?" -DefaultResponse "continue to Passwords, please."
 
     }
 
@@ -2023,14 +2023,14 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
             Write-Host "All Passwords matched, no migration required" -foregroundcolor green
         } else {
             Write-Host "Warning Import passwords is set to disabled so the above unmatched passwords will not have data migrated" -foregroundcolor red
-            Write-TimedMessage -Timeout 3 -Message "Press any key to continue or CTRL+C to quit" 
+            Write-TimedMessage -Timeout 3 -Message "Press any key to continue or CTRL+C to quit"  -DefaultResponse "continue wrap-up of passwords, please."
         }
     }
 
     # Save the results to resume from if needed
     $MatchedPasswords | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Passwords.json"
     $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
-    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Passwords Finished. Continue?"
+    Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Passwords Finished. Continue?"  -DefaultResponse "continue to Document/Article Updates, please."
 }
 
 ############################## Update ITGlue URLs on All Areas to Hudu #######################
@@ -2061,7 +2061,7 @@ foreach ($articleFound in $UpdateArticles) {
 }
 
 $articlesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedArticlesURL.json"
-Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. Continue?"  -DefaultResponse "continue to Assets, please."
 
 # Assets
 $assetsUpdated = @()
@@ -2087,7 +2087,7 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
 }
 
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
-Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?" -DefaultResponse "continue to Passwords Matching, please."
 
 # Passwords
 $passwordsUpdated = @()
@@ -2100,7 +2100,7 @@ foreach ($passwordFound in $UpdatePasswords.HuduObject) {
     }
 }
 $passwordsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedPasswordsURL.json"
-Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Password URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Password URLs Replaced. Continue?"  -DefaultResponse "continue to Asset Passwords Matching, please."
 
 # Asset Passwords
 $assetPasswordsUpdated = @()
@@ -2115,7 +2115,7 @@ foreach ($passwordFound in $UpdateAssetPasswords) {
     
 }
 $assetPasswordsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetPasswordsURL.json"
-Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Asset Passwords URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Asset Passwords URLs Replaced. Continue?"  -DefaultResponse "continue to Company Notes, please."
 
 # Company Notes
 $companyNotesUpdated = @()
@@ -2129,7 +2129,7 @@ foreach ($companyFound in $UpdateCompanyNotes.HuduCompanyObject) {
 
 }
 $companyNotesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedCompaniesURL.json"
-Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Company Notes URLs Replaced. Continue?"
+Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Company Notes URLs Replaced. Continue?"  -DefaultResponse "continue to Manual Actions, please."
 
 ############################### Generate Manual Actions Report ###############################
 
@@ -2259,6 +2259,6 @@ Write-Host "$(($MatchedPasswords | Measure-Object).count) : Passwords Migrated" 
 Write-Host "#######################################################" -ForegroundColor Green
 Write-Host "Manual Actions report can be found in ManualActions.html in the folder the script was run from"
 Write-Host "Logs of what was migrated can be found in the MigrationLogs folder"
-Write-TimedMessage -Message "Press any key to view the manual actions report or Ctrl+C to end" -Timeout 3600
+Write-TimedMessage -Message "Press any key to view the manual actions report or Ctrl+C to end" -Timeout 120  -DefaultResponse "continue, view generative Manual Actions webpage, please."
 
 Start-Process ManualActions.html

--- a/Initialize-Module.ps1
+++ b/Initialize-Module.ps1
@@ -338,6 +338,13 @@ if ($InitType -eq 'Full') {
         "1" {$ImportPasswords = $true}
         "2" {$ImportPasswords = $false}
     }
+
+    ############################### Unattended ###############################
+    while ($NonInteractive -notin (1,2)) {$NonInteractive = Read-Host "1) Run normally `n2) Perform this migration noninteractively `n(1/2)"}
+    switch ($NonInteractive) {
+        "1" {$NonInteractive = $false}
+        "2" {$NonInteractive = $true}
+    }    
 }
 ############################ Migration Logs Path ##############################
 $MigrationLogs = $environmentSettings.MigrationLogs

--- a/Private/Get-ConfigurationsImportMode.ps1
+++ b/Private/Get-ConfigurationsImportMode.ps1
@@ -1,5 +1,5 @@
 function Get-ConfigurationsImportMode {
-    $ImportOption = Read-Host "[1] [2] [3]"
+    $ImportOption = Write-TimedMessage -Message "[1] [2] [3]" -Timeout 10 -DefaultResponse 1
     if (!($ImportOption -in @(1, 2, 3))) {
         Write-Host "Please select 1, 2 or 3"
         $ImportOption = Get-ConfigurationsImportMode -ImportName $ImportName

--- a/Private/Get-FlexLayoutImportMode.ps1
+++ b/Private/Get-FlexLayoutImportMode.ps1
@@ -1,5 +1,5 @@
 function Get-FlexLayoutImportMode {
-    $ImportOption = Read-Host "[1] [2]"
+    $ImportOption = Write-TimedMessage -Message "[1] [2]" -Timeout 10 -DefaultResponse 1
     if (!($ImportOption -in @(1, 2))) {
         Write-Host "Please select 1 or 2"
         $ImportOption = Get-FlexLayoutImportMode -ImportName $ImportName

--- a/Private/Get-ImportMode.ps1
+++ b/Private/Get-ImportMode.ps1
@@ -3,7 +3,7 @@ function Get-ImportMode {
         [string]$ImportName
     )
     Write-Host "Importing $ImportName"
-    $ImportOption = Read-Host "[A] Import All unmapped $ImportName. [N] Import None of the unmapped $ImportName. [S] Select for each individual $ImportName (A/N/S)"
+    $ImportOption = $(Write-TimedMessage -Timout 8 -DefaultResponse "A" -Message "[A] Import All unmapped $ImportName. [N] Import None of the unmapped $ImportName. [S] Select for each individual $ImportName (A/N/S)")
     if (!($ImportOption -in @("A", "N", "S"))) {
         Write-Host "Please select A, N or S"
         $ImportOption = Get-ImportMode -ImportName $ImportName

--- a/Public/Write-TimedMessage.ps1
+++ b/Public/Write-TimedMessage.ps1
@@ -1,0 +1,35 @@
+function Write-TimedMessage {
+    Param(
+        [string]$Message,
+        [string]$DefaultResponse,
+        [int]$Timeout = 0  # Optional timeout in seconds for non-interactive mode
+    )
+
+    # Check non-interactive mode
+    if ($NonInteractive -eq $true) {
+        if ($Timeout -gt 0) {
+            $TimeoutStatement = "- Waiting for $Timeout seconds due to noninteractive mode. Control + c now if you do not wish to continue."
+        } else {
+            $TimeoutStatement = ""
+        }
+        if ($DefaultResponse -eq $null -or $DefaultResponse -eq ""){
+            $DefaultResponse="Proceeding"
+        }
+
+        if ($DefaultResponse -eq $null) {
+            Write-Host "$Message $TimeoutStatement"
+        } else {
+            Write-Host "$Message $TimeoutStatement - Noninteractive mode. Assuming response of ($DefaultResponse) after timeout."
+        }
+
+        # Apply timeout if specified
+        if ($Timeout -gt 0) {
+            Start-Sleep -Seconds $Timeout
+        }
+
+        return $DefaultResponse
+    } else {
+        # Interactive mode
+        return Read-Host -Prompt $Message
+    }
+}

--- a/Public/Write-TimedMessage.ps1
+++ b/Public/Write-TimedMessage.ps1
@@ -16,7 +16,7 @@ function Write-TimedMessage {
             $DefaultResponse="Proceeding"
         }
 
-        if ($DefaultResponse -eq $null) {
+        if ($null -eq $DefaultResponse) {
             Write-Host "$Message $TimeoutStatement"
         } else {
             Write-Host "$Message $TimeoutStatement - Noninteractive mode. Assuming response of ($DefaultResponse) after timeout."


### PR DESCRIPTION
Added noninteractive/unattended mode as an option in the initialization questionnaire, default-off

when enabled, all read-host messages/prompts throughout the script are still shown to the user, but with a default response (continue) and a timeout before assuming default. This allows a user who is watching the script run cancel something reasonably easily, or just set-and-forget

if left off, there is no change to behavior

It's proven pretty handy, particularly for testing, and allows migrations to be backgrounded and checked up on later without the need to babysit/monitor anything