### PR TITLE
remove not-allowed fields

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -709,7 +709,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
 
 	
     $ConfigAssetFieldsMap = { @{ 
-            'name'                      = $unmatchedImport."ITGObject".attributes."name"
+            # 'name'                      = $unmatchedImport."ITGObject".attributes."name"
             'hostname'                  = $unmatchedImport."ITGObject".attributes."hostname"
             'primary_ip'                = $unmatchedImport."ITGObject".attributes."primary-ip"
             'mac_address'               = $unmatchedImport."ITGObject".attributes."mac-address"
@@ -724,8 +724,8 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
             'warranty_expires_at'       = $unmatchedImport."ITGObject".attributes."warranty-expires-at"
             'installed_at'              = $unmatchedImport."ITGObject".attributes."installed-at"
             'purchased_at'              = $unmatchedImport."ITGObject".attributes."purchased-at"
-            'created_at'                = $unmatchedImport."ITGObject".attributes."created-at"
-            'updated_at'                = $unmatchedImport."ITGObject".attributes."updated-at"
+            # 'created_at'                = $unmatchedImport."ITGObject".attributes."created-at"
+            # 'updated_at'                = $unmatchedImport."ITGObject".attributes."updated-at"
             'configuration_type_name'   = $unmatchedImport."ITGObject".attributes."configuration-type-name"
             'configuration_type_kind'   = $unmatchedImport."ITGObject".attributes."configuration-type-kind"
             'configuration_status_name' = $unmatchedImport."ITGObject".attributes."configuration-status-name"


### PR DESCRIPTION
fields used for dates by activerecord and field called 'name' are illegal in custom fields given increased asset validation in hudu 2.37.0. 

These are fields in specific that were causing issues for users on 2.37.0, but should result in no expected change in behavior for previous versions. (Hudu went from ignoring unused fields to disallowing them, so this should fix that. 

As far as the issue below- 

```
Write-Error: ' {   "error": "Invalid custom fields",   "details": [     "Asset ID(s) {\u0022id\u0022 =\u003E 7, \u0022name\u0022 =\u003E \u0022Main\u0022}
```

can confirm that hotfix is coming pretty quickly which will allow for established asset linking methodology. The above issue is isolated to 2.37.0; 
However, those three fields, name, created_at, updated_at will still need to in ConfigAssetFieldsMap go for next realease in order to remain in working order.