### PR TITLE
Update ITGlue-Hudu-Migration.ps1

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2094,26 +2094,46 @@ Read-Host "Snapshot Point: Article URLs Replaced. Continue?"
 # Assets
 $assetsUpdated = @()
 foreach ($assetFound in $UpdateAssets.HuduObject) {
-    $fieldsFound = $assetFound.fields | Where-Object {$_.value -like "*$ITGURL*"}
     $originalAsset = $assetFound
-    foreach ($field in $fieldsFound) {
-        $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
-        $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-        if ($NewContent) {
-            Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with replaced Content" -ForegroundColor 'Red'
-            ($assetFound.fields | Where-Object {$_.id -eq $field.id}).value = $NewContent
-            $replacedStatus = 'replaced'
+    $replacedStatus = 'clean'
+    $customFields = @()
+
+    foreach ($field in $assetFound.fields) {
+        # Convert the caption to snake_case to match API expectations for 2.37.1
+        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
+
+        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
+            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+
+            if ($NewContent -and $NewContent -ne $field.value) {
+                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
+                $customFields += @{ $label = $NewContent }
+                $replacedStatus = 'replaced'
+            } else {
+                $customFields += @{ $label = $field.value }
+            }
+        } else {
+            # For other fields, preserve existing value (optional)
+            $customFields += @{ $label = $field.value }
         }
     }
-    if ($replacedStatus -ne 'replaced') {$replacedStatus = 'clean'}
-    else {
-        Write-Host "Updating Asset $($assetFound.name) with replaced field values" -ForegroundColor 'Green'
-        $AssetPost = Set-HuduAsset -asset_layout_id $assetFound.asset_layout_id -Name $assetFound.name -AssetId $assetFound.id -CompanyId $assetFound.company_id -Fields $assetFound.fields
+
+    if ($replacedStatus -eq 'replaced') {
+        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
+        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
+            name              = $assetFound.name
+            asset_layout_id   = $assetFound.asset_layout_id
+            custom_fields     = $customFields
+        }
     }
-    $assetsUpdated = $assetsUpdated + @{"status" = $replacedStatus; "original_asset" = $originalAsset; "updated_asset" = $AssetPost.asset}
 
+    $assetsUpdated += @{
+        status         = $replacedStatus
+        original_asset = $originalAsset
+        updated_asset  = $AssetPost.asset
+    }
 }
-
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
 Read-Host "Snapshot Point: Assets URLs Replaced. Continue?"
 


### PR DESCRIPTION
Tested and fixed for 2.37.1, though prior to 2.37.0, the previous method was viable/working

regex replacement/transforms for updating assets (layout fields: 500, 501, 502, below), which creates ReplacedAssetsURL.json

```
$TempLayoutFields = @(
    @{
        label        = 'Imported from ITGlue'
        field_type   = 'Date'
        show_in_list = 'false'
        position     = 500
    },
    @{
        label        = 'ITGlue URL'
        field_type   = 'Text'
        show_in_list = 'false'
        position     = 501
    },
    @{
        label        = 'ITGlue ID'
        field_type   = 'Text'
        show_in_list = 'false'
        position     = 502
    }
```

Before transforming these would result in error, like either of the below (if wrapped in try/catch with write-error for exception). This is due to change in custom fields updating for assets.

if using 2.37.1, this is what you'd see during this portion before this change:
(invalid custom field, itglue id, 

![image](https://github.com/user-attachments/assets/fc6bb693-251c-48a1-980a-9ee10f45f52c)

if using 2.37.1, this is what you'd see during this portion after this change:

![image](https://github.com/user-attachments/assets/bf4e6b27-ac98-459e-abe7-a80a4b4f6f44)



