### PR TITLE
Allow for duplicitous itglue companyname

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -109,13 +109,17 @@ if ((get-host).version.major -ne 7) {
 
 
 #Get the Hudu API Module if not installed
-if ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.4') {
+$HAPImodulePath = "C:\Users\$env:USERNAME\Documents\GitHub\HuduAPI\HuduAPI\HuduAPI.psm1"
+if (Test-Path $HAPImodulePath) {
+    Import-Module $HAPImodulePath -Force
+    Write-Host "Module imported from $HAPImodulePath"
+} elseif ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.4') {
+    Write-Host "Module imported from $HAPImodulePath"
     Import-Module HuduAPI
 } else {
     Install-Module HuduAPI -MinimumVersion 2.4.5 -Scope CurrentUser
     Import-Module HuduAPI
-}
-  
+}  
 #Login to Hudu
 New-HuduAPIKey $HuduAPIKey
 New-HuduBaseUrl $HuduBaseDomain
@@ -183,21 +187,26 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
     $ITGCompaniesFromCSV = Import-CSV (Join-Path -Path $ITGlueExportPath -ChildPath "organizations.csv")
 
     Write-Host "$($ITGCompanies.count) ITG Glue Companies Found" 
-	
-	
-	
+    $nameTracker = @{}
+    $MatchedCompanies = foreach ($itgcompany in $ITGCompanies) {
+        $originalName = $itgcompany.attributes.name
 
-    $MatchedCompanies = foreach ($itgcompany in $ITGCompanies ) {
-        $HuduCompany = $HuduCompanies | where-object -filter { $_.name -eq $itgcompany.attributes.name }
-        if ($InternalCompany -eq $itgcompany.attributes.name) {
-            $intCompany = $true
+        # Create a unique name if it's already been seen
+        if ($nameTracker.ContainsKey($originalName)) {
+            $nameTracker[$originalName]++
+            $uniqueName = "$originalName-$($nameTracker[$originalName])"
         } else {
-            $intCompany = $false
+            $nameTracker[$originalName] = 0
+            $uniqueName = $originalName
         }
-	
+
+        $HuduCompany = $HuduCompanies | Where-Object -Filter { $_.name -eq $originalName }
+
+        $intCompany = $InternalCompany -eq $originalName
+
         if ($HuduCompany) {
             [PSCustomObject]@{
-                "CompanyName"       = $itgcompany.attributes.name
+                "CompanyName"       = $uniqueName
                 "ITGID"             = $itgcompany.id
                 "HuduID"            = $HuduCompany.id
                 "Matched"           = $true
@@ -205,11 +214,10 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
                 "HuduCompanyObject" = $HuduCompany
                 "ITGCompanyObject"  = $itgcompany
                 "Imported"          = "Pre-Existing"
-			
             }
         } else {
             [PSCustomObject]@{
-                "CompanyName"       = $itgcompany.attributes.name
+                "CompanyName"       = $uniqueName
                 "ITGID"             = $itgcompany.id
                 "HuduID"            = ""
                 "Matched"           = $false


### PR DESCRIPTION
Super simple, allows for companies by same name in ITglue to be created with unique name (dash-number appended).  

fixes #34
(will be a draft PR until testing finishes) 

![image](https://github.com/user-attachments/assets/d08108ad-875f-410c-b6eb-8c7b39c1db24)

<img width="464" alt="image" src="https://github.com/user-attachments/assets/142c1105-1a96-49b2-b1fc-b08c4346f86c" />

Locations and other assets seem to be attributed just fine and itgcompany object doesnt get transformed. To be sure, doing a full migration and manually doing a once-over, but we're about halfway through without issue