### PR TITLE
Chore/disallowed versions check

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -1,11 +1,25 @@
-# Main settings load
-. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+# Check if this is a direct run, and load the logs if so the first time.
+if (-not ($FirstTimeLoad -eq 1)) {
+    # General Settings Load
+    . $PSScriptRoot\..\Initialize-Module.ps1 -InitType 'Lite'
+    
+    # Add Replace URL functions
+    . $PSScriptRoot\..\Private\ConvertTo-HuduURL.ps1
 
-# Replace TestImage() with Invoke-ImageTest()
+    Write-Host "Checking for Matched Variables"
+    if (-not $MatchedPasswords) {$MatchedPasswords = (Get-Content -path "$MigrationLogs\Passwords.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedAssetPasswords) {$MatchedAssetPasswords = (Get-Content -path "$MigrationLogs\AssetPasswords.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedArticleBase) {$MatchedArticleBase = Get-Content "$MigrationLogs\ArticleBase.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    if (-not $MatchedArticles) {$MatchedArticles = (Get-Content -path "$MigrationLogs\Articles.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedCompanies) {$MatchedCompanies = (Get-Content -path "$MigrationLogs\Companies.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedConfigurations) {$MatchedConfigurations = Get-Content "$MigrationLogs\Configurations.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    if (-not $MatchedAssets) {$MatchedAssets = Get-Content "$MigrationLogs\Assets.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    # Set the context so logs don't run again unless the powershell window gets closed.
+    $FirstTimeLoad = 1
+}
+
+# Load Invoke-ImageTest()
 . $PSScriptRoot\Private\Invoke-ImageTest.ps1
-
-# Staging Directory
-$StagingRoot = (Get-Item $MigrationLogs).Parent.FullName
 
 # Attachments Path
 $AttachmentsPath = (Join-Path -Path $ITGLueExportPath -ChildPath "attachments")
@@ -152,7 +166,7 @@ else {
 }
 
 ## Starting main script
-Write-Host "Starting script. Files will be saved into $StagingRoot Press CTRL+C to cancel" -ForegroundColor Yellow
+Write-Host "Starting script. Press CTRL+C to cancel" -ForegroundColor Yellow
 Pause
 
 Write-host "Loading Asset Log"
@@ -208,6 +222,5 @@ if ($CSVMapping) {
     }
 }
 
-# Write-Host "You will need to take $StagingRoot and sync it to the appropriate backend storage"
 Write-Host "All attachments have been processed."
 Pause

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2096,46 +2096,26 @@ Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. C
 # Assets
 $assetsUpdated = @()
 foreach ($assetFound in $UpdateAssets.HuduObject) {
+    $fieldsFound = $assetFound.fields | Where-Object {$_.value -like "*$ITGURL*"}
     $originalAsset = $assetFound
-    $replacedStatus = 'clean'
-    $customFields = @()
-
-    foreach ($field in $assetFound.fields) {
-        # Convert the caption to snake_case to match API expectations for 2.37.1
-        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
-
-        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
-            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
-            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-
-            if ($NewContent -and $NewContent -ne $field.value) {
-                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
-                $customFields += @{ $label = $NewContent }
-                $replacedStatus = 'replaced'
-            } else {
-                $customFields += @{ $label = $field.value }
-            }
-        } else {
-            # For other fields, preserve existing value (optional)
-            $customFields += @{ $label = $field.value }
+    foreach ($field in $fieldsFound) {
+        $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+        $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+        if ($NewContent) {
+            Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with replaced Content" -ForegroundColor 'Red'
+            ($assetFound.fields | Where-Object {$_.id -eq $field.id}).value = $NewContent
+            $replacedStatus = 'replaced'
         }
     }
-
-    if ($replacedStatus -eq 'replaced') {
-        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
-        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
-            name              = $assetFound.name
-            asset_layout_id   = $assetFound.asset_layout_id
-            custom_fields     = $customFields
-        }
+    if ($replacedStatus -ne 'replaced') {$replacedStatus = 'clean'}
+    else {
+        Write-Host "Updating Asset $($assetFound.name) with replaced field values" -ForegroundColor 'Green'
+        $AssetPost = Set-HuduAsset -asset_layout_id $assetFound.asset_layout_id -Name $assetFound.name -AssetId $assetFound.id -CompanyId $assetFound.company_id -Fields $assetFound.fields
     }
+    $assetsUpdated = $assetsUpdated + @{"status" = $replacedStatus; "original_asset" = $originalAsset; "updated_asset" = $AssetPost.asset}
 
-    $assetsUpdated += @{
-        status         = $replacedStatus
-        original_asset = $originalAsset
-        updated_asset  = $AssetPost.asset
-    }
 }
+
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
 Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?" -DefaultResponse "continue to Passwords Matching, please."
 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -121,10 +121,13 @@ New-HuduAPIKey $HuduAPIKey
 New-HuduBaseUrl $HuduBaseDomain
 
 # Check we have the correct version
+# Check we have the correct version
 $RequiredHuduVersion = "2.1.5.9"
+$DisallowedVersions = @([version]"2.37.0")
 $HuduAppInfo = Get-HuduAppInfo
-If ([version]$HuduAppInfo.version -lt [version]$RequiredHuduVersion) {
-    Write-Host "This script requires at least version $RequiredHuduVersion. Please update your version of Hudu and run the script again. Your version is $($HuduAppInfo.version)"
+$CurrentVersion = [version]$HuduAppInfo.version
+if ($CurrentVersion -lt [version]$RequiredHuduVersion -or $DisallowedVersions -contains $CurrentVersion) {
+    Write-Host "This script requires at least version $RequiredHuduVersion and cannot run with version $CurrentVersion. Please update your version of Hudu."
     exit 1
 }
 


### PR DESCRIPTION
added an array of disallowed versions (currently only 2.37.0), This can save a lot of trouble for anyone who might attempt migrating to a hudu 2.37.0 instance. 

#43 

Hopefully there aren't any other hudu versions that we need to add to this, but right now, it's just that one version.
<img width="855" alt="image" src="https://github.com/user-attachments/assets/443392c0-879e-49d7-a1ee-e43f65a0dd74" />
