### PR TITLE
Fix/otp and password validation

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -1,11 +1,25 @@
-# Main settings load
-. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+# Check if this is a direct run, and load the logs if so the first time.
+if (-not ($FirstTimeLoad -eq 1)) {
+    # General Settings Load
+    . $PSScriptRoot\..\Initialize-Module.ps1 -InitType 'Lite'
+    
+    # Add Replace URL functions
+    . $PSScriptRoot\..\Private\ConvertTo-HuduURL.ps1
 
-# Replace TestImage() with Invoke-ImageTest()
+    Write-Host "Checking for Matched Variables"
+    if (-not $MatchedPasswords) {$MatchedPasswords = (Get-Content -path "$MigrationLogs\Passwords.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedAssetPasswords) {$MatchedAssetPasswords = (Get-Content -path "$MigrationLogs\AssetPasswords.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedArticleBase) {$MatchedArticleBase = Get-Content "$MigrationLogs\ArticleBase.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    if (-not $MatchedArticles) {$MatchedArticles = (Get-Content -path "$MigrationLogs\Articles.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedCompanies) {$MatchedCompanies = (Get-Content -path "$MigrationLogs\Companies.json" | ConvertFrom-json -depth 100) }
+    if (-not $MatchedConfigurations) {$MatchedConfigurations = Get-Content "$MigrationLogs\Configurations.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    if (-not $MatchedAssets) {$MatchedAssets = Get-Content "$MigrationLogs\Assets.json" -raw | Out-String | ConvertFrom-Json -depth 100}
+    # Set the context so logs don't run again unless the powershell window gets closed.
+    $FirstTimeLoad = 1
+}
+
+# Load Invoke-ImageTest()
 . $PSScriptRoot\Private\Invoke-ImageTest.ps1
-
-# Staging Directory
-$StagingRoot = (Get-Item $MigrationLogs).Parent.FullName
 
 # Attachments Path
 $AttachmentsPath = (Join-Path -Path $ITGLueExportPath -ChildPath "attachments")
@@ -152,7 +166,7 @@ else {
 }
 
 ## Starting main script
-Write-Host "Starting script. Files will be saved into $StagingRoot Press CTRL+C to cancel" -ForegroundColor Yellow
+Write-Host "Starting script. Press CTRL+C to cancel" -ForegroundColor Yellow
 Pause
 
 Write-host "Loading Asset Log"
@@ -208,6 +222,5 @@ if ($CSVMapping) {
     }
 }
 
-# Write-Host "You will need to take $StagingRoot and sync it to the appropriate backend storage"
 Write-Host "All attachments have been processed."
 Pause

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2096,46 +2096,26 @@ Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. C
 # Assets
 $assetsUpdated = @()
 foreach ($assetFound in $UpdateAssets.HuduObject) {
+    $fieldsFound = $assetFound.fields | Where-Object {$_.value -like "*$ITGURL*"}
     $originalAsset = $assetFound
-    $replacedStatus = 'clean'
-    $customFields = @()
-
-    foreach ($field in $assetFound.fields) {
-        # Convert the caption to snake_case to match API expectations for 2.37.1
-        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
-
-        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
-            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
-            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-
-            if ($NewContent -and $NewContent -ne $field.value) {
-                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
-                $customFields += @{ $label = $NewContent }
-                $replacedStatus = 'replaced'
-            } else {
-                $customFields += @{ $label = $field.value }
-            }
-        } else {
-            # For other fields, preserve existing value (optional)
-            $customFields += @{ $label = $field.value }
+    foreach ($field in $fieldsFound) {
+        $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+        $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+        if ($NewContent) {
+            Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with replaced Content" -ForegroundColor 'Red'
+            ($assetFound.fields | Where-Object {$_.id -eq $field.id}).value = $NewContent
+            $replacedStatus = 'replaced'
         }
     }
-
-    if ($replacedStatus -eq 'replaced') {
-        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
-        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
-            name              = $assetFound.name
-            asset_layout_id   = $assetFound.asset_layout_id
-            custom_fields     = $customFields
-        }
+    if ($replacedStatus -ne 'replaced') {$replacedStatus = 'clean'}
+    else {
+        Write-Host "Updating Asset $($assetFound.name) with replaced field values" -ForegroundColor 'Green'
+        $AssetPost = Set-HuduAsset -asset_layout_id $assetFound.asset_layout_id -Name $assetFound.name -AssetId $assetFound.id -CompanyId $assetFound.company_id -Fields $assetFound.fields
     }
+    $assetsUpdated = $assetsUpdated + @{"status" = $replacedStatus; "original_asset" = $originalAsset; "updated_asset" = $AssetPost.asset}
 
-    $assetsUpdated += @{
-        status         = $replacedStatus
-        original_asset = $originalAsset
-        updated_asset  = $AssetPost.asset
-    }
 }
+
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
 Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?" -DefaultResponse "continue to Passwords Matching, please."
 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2037,25 +2037,35 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                             username          = $unmatchedPassword.ITGObject.attributes.username
                             otpsecret         = $validated_otp
                         }
-
-                        $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password
-
-
-                        $unmatchedPassword.matched = $true
-                        $unmatchedPassword.HuduID = $HuduNewPassword.id
-                        $unmatchedPassword."HuduObject" = $HuduNewPassword
-                        $unmatchedPassword.Imported = "Created-By-Script"
-
-                        $ImportsMigrated = $ImportsMigrated + 1
-
-                        Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
-
+                        if ([string]::IsNullOrWhiteSpace($passwordRaw) -or $passwordRaw.Length -lt 1) {
+                            $manualActions.add([PSCustomObject]@{
+                                name              = "$($unmatchedPassword.ITGObject.attributes.name)"
+                                company_id        = $company.HuduCompanyObject.ID
+                                description       = $unmatchedPassword.ITGObject.attributes.notes
+                                passwordable_type = $PasswordableType
+                                passwordable_id   = $ParentItemID
+                                in_portal         = $false
+                                password          = ""
+                                url               = $unmatchedPassword.ITGObject.attributes.url
+                                username          = $unmatchedPassword.ITGObject.attributes.username
+                                otpsecret         = "removed for security purposes"
+                                problem           = "password was null or empty"
+                            })
+                            $unmatchedPassword.matched = $false
+                            Write-host "$($HuduNewPassword.Name) Has been skipped and added to manual actions due to being empty"                            
+                        } else {
+                            $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password 
+                            $unmatchedPassword.matched = $true
+                            $unmatchedPassword.HuduID = $HuduNewPassword.id
+                            $unmatchedPassword."HuduObject" = $HuduNewPassword
+                            $unmatchedPassword.Imported = "Created-By-Script"
+                            $ImportsMigrated = $ImportsMigrated + 1
+                            Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
+                        }
                     }
                 }
             }
         }
-
-
     } else {
         if ($UnmappedPasswordCount -eq 0) {
             Write-Host "All Passwords matched, no migration required" -foregroundcolor green


### PR DESCRIPTION
Includes more stringent validation for OTP and Password fields in @Passwordsplat

![image](https://github.com/user-attachments/assets/ee5d6ee7-7df3-4e22-8aae-df34d494cef3)

This also sets OTPs to null in @passwordsplat if longer than allowable or if not valid base32.
As for these OTPs, I've found that we have a few in ITglue, all of same-length, 103 chars

![image](https://github.com/user-attachments/assets/59bb6e1e-98ff-4bc4-be49-8b8fa4705097)

fixes #44 