### PR TITLE
Chore/cast numerals 2.37.1

### DIFF
--- a/Public/Get-CastIfNumeric.ps1
+++ b/Public/Get-CastIfNumeric.ps1
@@ -1,0 +1,19 @@
+function Get-CastIfNumeric {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Value
+    )
+
+    if ($Value -is [string]) {
+        $Value = $Value.Trim()
+    }
+
+    if ($Value -match '^[+-]?\d+(\.\d+)?$') {
+        try {
+            return [int][double]$Value
+        } catch {
+            return 0
+        }
+    }
+    return $Value
+}


### PR DESCRIPTION
This fix for Asset Number fields is relevent to 2.37.1, and possibly isolated to just this version. 
#46 

2.37.0 and 2.37.1 both include more strict number validation, and only will allow for ints. 
It sounds like this number validation logic might be relaxed later on. Since I mainly test with newest/beta, however, this is pretty handy for avoiding issues.

Alternatively, 2.37.1 could be added to disallowed versions array in the same way as 2.37.0 is, [here](https://github.com/lwhitelock/ITGlue-Hudu-Migration/pull/42), but since 2.37.1 works fine with this PR and [this fix](https://github.com/lwhitelock/ITGlue-Hudu-Migration/pull/38) combined, it might be easier to just support 2.37.1 and conditionally finesse this data.