### PR TITLE
Feat/scopedimportmode

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -124,7 +124,7 @@ New-HuduAPIKey $HuduAPIKey
 New-HuduBaseUrl $HuduBaseDomain
 
 # Check we have the correct version
-$RequiredHuduVersion = "2.63.1"
+$RequiredHuduVersion = "2.36.1"
 $HuduAppInfo = Get-HuduAppInfo
 If ([version]$HuduAppInfo.version -lt [version]$RequiredHuduVersion) {
     Write-Host "This script requires at least version $RequiredHuduVersion. Please update your version of Hudu and run the script again. Your version is $($HuduAppInfo.version)"

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -124,7 +124,7 @@ New-HuduAPIKey $HuduAPIKey
 New-HuduBaseUrl $HuduBaseDomain
 
 # Check we have the correct version
-$RequiredHuduVersion = "2.37.1"
+$RequiredHuduVersion = "2.63.1"
 $HuduAppInfo = Get-HuduAppInfo
 If ([version]$HuduAppInfo.version -lt [version]$RequiredHuduVersion) {
     Write-Host "This script requires at least version $RequiredHuduVersion. Please update your version of Hudu and run the script again. Your version is $($HuduAppInfo.version)"

--- a/Initialize-Module.ps1
+++ b/Initialize-Module.ps1
@@ -43,7 +43,36 @@ function ConvertSecureStringToPlainText {
     [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
     return $plainText
 }
+function Select-ObjectFromList($objects,$message,$allowNull = $false) {
+    $validated=$false
+    while ($validated -eq $false){
 
+        for ($i = 0; $i -lt $objects.Count; $i++) {
+            $object = $objects[$i]
+            if ($null -ne $object.name) {
+                Write-Host "$($i+1): $($object.name)"
+            } elseif ($null -ne $object.attributes.name) {
+                Write-Host "$($i+1): $($object.attributes.name)"
+            } else {
+                Write-Host "$($i+1): $($object)"
+            }
+        }
+        if ($allowNull -eq $true) {
+            Write-Host "0: None/Custom"
+        }        
+        Write-Host $message
+        $choice = Read-Host
+        if ($null -eq $choice -or $choice -lt 0 -or $choice -gt $objects.Count +1) {
+            Write-Host -message "Invalid selection. Please enter a number from above"
+        }
+        if ($choice -eq 0 -and $true -eq $allowNull) {
+            return $null
+        }
+        if ($null -ne $objects[$choice - 1]){
+            return $objects[$choice - 1]
+        }
+    }
+}
 
 # Prompt the user for various settings and save the responses
 function CollectAndSaveSettings {
@@ -344,7 +373,14 @@ if ($InitType -eq 'Full') {
     switch ($NonInteractive) {
         "1" {$NonInteractive = $false}
         "2" {$NonInteractive = $true}
-    }    
+    }
+
+    ############################### Scoped ###############################
+    while ($ScopedMigration -notin (1,2)) {$ScopedMigration = Read-Host "1) Run normally `n2) Perform migration scoped to certain companies `n(1/2)"}
+    switch ($ScopedMigration) {
+        "1" {$ScopedMigration = $false}
+        "2" {$ScopedMigration = $true}
+    }
 }
 ############################ Migration Logs Path ##############################
 $MigrationLogs = $environmentSettings.MigrationLogs

--- a/Public/Set-MigrationScope.ps1
+++ b/Public/Set-MigrationScope.ps1
@@ -1,0 +1,64 @@
+function Set-MigrationScope {
+    param(
+        [Parameter(Mandatory)]
+        [array]$AllITGCompanies,
+
+        [Parameter(Mandatory)]
+        [string]$InternalCompany
+    )
+
+    Write-Host "Scoped Migration Mode. Select companies to migrate from IT Glue."
+
+    $ScopedForCompanies = [System.Collections.ArrayList]@()
+    while ($true) {
+        $selection = Select-ObjectFromList -allowNull $true `
+            -message "Select a number corresponding to a company to add to migration list. Press Enter to finish." `
+            -objects $AllITGCompanies
+
+        if ($null -eq $selection) { break }
+
+        [void]$ScopedForCompanies.Add($selection)
+    }
+
+    if ($ScopedForCompanies.Count -eq 0) {
+        Write-Error "No companies selected for scoped migration. Exiting."
+        exit 1
+    }
+
+    # Deduplicate based on ID
+    $ScopedForCompanies = $ScopedForCompanies | Sort-Object { $_.id } -Unique
+
+    $companyNames = $ScopedForCompanies | ForEach-Object { $_.attributes.name }
+    $confirmationMessage = "You've elected to migrate these companies:`n$($companyNames -join ', ')`nContinue?"
+    $userChoice = Select-ObjectFromList -objects @("yes", "no") -message $confirmationMessage
+
+    if ($userChoice -eq "no") {
+        Write-Host "Migration cancelled by user."
+        exit 1
+    }
+
+    Write-Host "Limiting migration to selected companies..."
+
+    # Return filtered list (with internal company added if not already present)
+    $ScopedIds = $ScopedForCompanies.id
+    $ScopedList = $AllITGCompanies | Where-Object {
+        $ScopedIds -contains $_.id -or $_.attributes.name -eq $InternalCompany
+    } | Sort-Object id -Unique
+
+    return $ScopedList
+}
+
+function Filter-ScopedAssets {
+    param (
+        [array]$Layouts,
+        [array]$ScopedCompanyIds
+    )
+
+    foreach ($Layout in $Layouts) {
+        $Layout.ITGAssets = $Layout.ITGAssets | Where-Object {
+            $ScopedCompanyIds -contains $_.attributes.'organization-id'
+        }
+    }
+
+    return $Layouts
+}


### PR DESCRIPTION
Solves #13 

This was originally developed and tested with Hudu Technologies fork with a handful of hosts on 2.37.1. 

I've also checked out to this fork and ran it against some hosts on 2.36.3 to the same effect

There is no change to expected behavior when not performing scoped migration. 

when performing scoped migration, you simply add however many ITGcompanies you want. It also includes your internal company, just in case you don't select it.

Section of Selection:
![image](https://github.com/user-attachments/assets/134e0879-20a9-4f49-937b-147dd6d9eea8)

Scoped migration from this fork to 2.36.3 hudu instance
<img width="782" alt="image" src="https://github.com/user-attachments/assets/006df2b5-c9dc-4d3d-9676-3b7236ba8041" />

Scoped migration from Hudu Technologies fork to 2.37.1 instance
<img width="1565" alt="image" src="https://github.com/user-attachments/assets/62d136d6-1919-4b7a-9d89-f00753aa0b9d" />


