### PR TITLE
Feat/article attachments

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1682,6 +1682,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
                             ITG_URL       = "$ITGURL/$($Article.ITGLocator)"
                         }
                 	$null = $ManualActions.add($ManualLog)
+		     }
                 }
             }
 


### PR DESCRIPTION
Uploads / Attachments for Articles had been being skipped and placed in manualactions. Now, we try/catch upload these attachments and only if they fail, we place in manualactions
<img width="908" alt="image" src="https://github.com/user-attachments/assets/96ba8104-3547-49a9-88e9-2370122b6d29" />
