### PR TITLE
Update ITGlue-Hudu-Migration.ps1

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1829,7 +1829,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
                                     continue
                                 }
                                 try {                                    
-                                    $NewImageURL = $UploadImage.public_photo.url.replace($HuduBaseDomain, '')
+                                    $NewImageURL = $UploadImage.public_photo.url.replace($HuduBaseDomain, '/')
                                     
                                     # Update the <img> tag src
                                     $imageObject.src = [string]$NewImageURL


### PR DESCRIPTION
Invalid relative path was causing the images to load from the path of the article instead of the root hostname. Replaced empty space with "/" to force the relative path to be from root of the hostname