### PR TITLE
remove slash in image url replace

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1830,7 +1830,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
                                     continue
                                 }
                                 try {                                    
-                                    $NewImageURL = $UploadImage.public_photo.url.replace($HuduBaseDomain, '/')
+                                    $NewImageURL = $UploadImage.public_photo.url.replace($HuduBaseDomain, '')
                                     
                                     # Update the <img> tag src
                                     $imageObject.src = [string]$NewImageURL


### PR DESCRIPTION
the url property of upload object starts with a slash, so this results in a double-leading slash

I caught it last night letting my dog out and checking the evenings tests- 

<img width="429" height="320" alt="image" src="https://github.com/user-attachments/assets/799f44b2-2e7f-41b7-9999-9a692bd0d18d" />

super quick de-bork and easy fix for anyone retroactively if applied with double-slash

the top two images are a normal in-doc image, one absolute, one relative (in itglue)

the third and fourth image is absolute path to image from different doc
